### PR TITLE
make sure that the video doesn't overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@
       <div class="row">
         <div class="medium-12 columns">
           <div class="flex-video">
-            <iframe width="1280" height="720" src="//www.youtube.com/embed/pnkyQtqiwvg?theme=light" frameborder="0" allowfullscreen></iframe>
+            <iframe width="100%" height="720" src="//www.youtube.com/embed/pnkyQtqiwvg?theme=light" frameborder="0" allowfullscreen></iframe>
           </div>
           <p><b>Note:</b> The video uses a modified version of my model with most numbers tweaked to protect my real plan.</p>
         </div>


### PR DESCRIPTION
Instead of giving it a fixed size of 1280px, giving it a 100% of the container works better IMO
